### PR TITLE
Quick fix for v1.2.1

### DIFF
--- a/futurerestored.sh
+++ b/futurerestored.sh
@@ -112,6 +112,8 @@ sleep 3
 
 if [ "$skip_rdboot" = true ]; then
     printr "[*] Skipped booting ramdisk as specified"
+    printg "[*] Press enter when you want to continue"
+    read skiprdbootdone
 else
     printg "[*] Booting ramdisk"
     cd $script_path/SSHRD_Script && chmod +x sshrd.sh && ./sshrd.sh boot


### PR DESCRIPTION
When using `--skip-rdboot` skip would automatically continue after 2-3s
In this version it asks user to press enter to continue (if device isn't in Sshrd Ramdisk yet)